### PR TITLE
Wrap pip

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -14,7 +14,11 @@ then
   rm -r dist
 else
   echo "Downloading from pip"
-  pip download -d ./whl kolibri
+  WHL_DIR="/tmp/whl"
+  DOCKER_ID=$(docker create python:3 pip download -d $WHL_DIR kolibri)
+  docker start -a $DOCKER_ID
+  docker cp $DOCKER_ID:$WHL_DIR .
+  docker rm $DOCKER_ID
 fi
 
 echo "--- :android: Build APK"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -1,7 +1,6 @@
 #! /bin/bash
 set -eo pipefail
 
-mkdir -p whl
 
 echo "--- Downloading whl file"
 
@@ -10,8 +9,7 @@ if [[ $LE_TRIGGERED_FROM_BUILD_ID ]]
 then
   echo "Downloading from triggered build"
   buildkite-agent artifact download 'dist/*.whl' . --build ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
-  mv dist/* whl/
-  rm -r dist
+  mv dist whl
 else
   echo "Downloading from pip"
   WHL_DIR="/tmp/whl"


### PR DESCRIPTION
Wrapping a `pip download` command in docker. Initially tried virtualenv, but because the host doesn't have `pip` installed, and it downloads it on-the-fly, it's not a reliable means of isolation.