### PR TITLE
Dev Cache/Build Overhaul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,20 +44,8 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 USER kivy:kivy
 WORKDIR /home/kivy
 
-# Needed to setup & install necessary p4a environment
-COPY --chown=kivy:kivy whitelist.txt project_info.template ./
-COPY --chown=kivy:kivy scripts/create_dummy_project_info.py scripts/
+COPY --chown=kivy:kivy . .
 
-# Makes a dummy project_info, pretty mutch just ot get pew init to run
-# Downlads p4a and all python dependencies for packaging in android
-RUN python ./scripts/create_dummy_project_info.py && pew init android
+ENTRYPOINT [ "make" ]
 
-COPY --chown=kivy:kivy assets assets
-
-# Could probably include this earlier on
-COPY --chown=kivy:kivy icon.png .
-COPY --chown=kivy:kivy src/main.py src/
-
-# Extract .whl files and build the apk
-# Assumes that you're mounting the sourcecode at runtime
-CMD make kolibri.apk
+CMD [ "kolibri.apk" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ RUN dpkg --add-architecture i386 && \
     python-wxgtk3.0 \
     && apt-get clean
 
+
+# Allows us to invalidate cache if those repos update.
+# Intentionally not pinning for dev velocity.
+ADD https://github.com/kollivier/python-for-android/archive/webview_plus.zip p4a.zip
+ADD https://github.com/kollivier/pyeverywhere/archive/dev.zip pew.zip
+
 # install python dependencies
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
   python get-pip.py && \
@@ -43,6 +49,9 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 USER kivy:kivy
 WORKDIR /home/kivy
+
+# Initializes the directory, owned by new user. Volume mounts adopt existing permissions, etc.
+RUN mkdir ~/.local ~/.pyeverywhere
 
 COPY --chown=kivy:kivy . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,5 @@ COPY --chown=kivy:kivy icon.png .
 COPY --chown=kivy:kivy src/main.py src/
 
 # Extract .whl files and build the apk
-CMD make Kolibri%.apk
+# Assumes that you're mounting the sourcecode at runtime
+CMD make kolibri.apk

--- a/Makefile
+++ b/Makefile
@@ -16,24 +16,28 @@ src/kolibri:
 project_info.json: project_info.template src/kolibri scripts/create_project_info.py
 	python ./scripts/create_project_info.py
 
+.PHONY: p4a_android_distro
+p4a_android_distro: whitelist.txt project_info.json
+	pew init android
 
 ifdef P4A_RELEASE_KEYSTORE_PASSWD
 pew_release_flag = --release
 endif
 
+.PHONY: kolibri.apk
 # Buld the debug version of the apk
-kolibri.apk: project_info.json
+kolibri.apk: p4a_android_distro
 	pew build android $(pew_release_flag)
 
 # DOCKER BUILD
 
 # Build the docker image. Should only ever need to be rebuilt if project requirements change.
 # Makes dummy file
-build_docker: project_info.template Dockerfile
+.PHONY: build_docker
+build_docker: Dockerfile
 	docker build -t android_kolibri .
-	touch build_docker
 
 # Run the docker image.
 # TODO Would be better to just specify the file here?
-run_docker: clean project_info.json build_docker
+run_docker: build_docker
 	./scripts/rundocker.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-VPATH = ./dist/android/
-
 # Clear out apks
 clean:
 	- rm -rf dist/android/*.apk project_info.json ./src/kolibri
@@ -24,7 +22,7 @@ pew_release_flag = --release
 endif
 
 # Buld the debug version of the apk
-Kolibri%.apk: project_info.json
+kolibri.apk: project_info.json
 	pew build android $(pew_release_flag)
 
 # DOCKER BUILD

--- a/scripts/rundocker.sh
+++ b/scripts/rundocker.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
+set -e
+
 CONTAINER_HOME=/home/kivy
 
 # create the container to be used throughout the script
 CONTAINER_ID=$(docker create -it \
-  --mount type=bind,src=${PWD}/whl,dst=${CONTAINER_HOME}/whl \
-  --mount type=bind,src=${PWD}/src,dst=${CONTAINER_HOME}/src \
-  --mount type=bind,src=${PWD}/scripts,dst=${CONTAINER_HOME}/scripts \
-  --mount type=bind,src=${PWD}/Makefile,dst=${CONTAINER_HOME}/Makefile \
-  --mount type=bind,src=${PWD}/src/main.py,dst=${CONTAINER_HOME}/src/main.py \
-  --mount type=bind,src=${PWD}/project_info.json,dst=${CONTAINER_HOME}/project_info.json \
   --env P4A_RELEASE_KEYSTORE=${CONTAINER_HOME}/$(basename "${P4A_RELEASE_KEYSTORE}") \
   --env P4A_RELEASE_KEYALIAS \
   --env P4A_RELEASE_KEYSTORE_PASSWD \

--- a/scripts/rundocker.sh
+++ b/scripts/rundocker.sh
@@ -4,8 +4,15 @@ set -e
 
 CONTAINER_HOME=/home/kivy
 
+# Specifies the name of the docker volume used to store p4a cache
+P4A_CACHE=p4a_cache
+PEW_CACHE=pew_cache
+
 # create the container to be used throughout the script
+# creates a volume for reuse between builds, holding p4a's android distro
 CONTAINER_ID=$(docker create -it \
+  --mount type=volume,src=${P4A_CACHE},dst=${CONTAINER_HOME}/.local \
+  --mount type=volume,src=${PEW_CACHE},dst=${CONTAINER_HOME}/.pyeverywhere \
   --env P4A_RELEASE_KEYSTORE=${CONTAINER_HOME}/$(basename "${P4A_RELEASE_KEYSTORE}") \
   --env P4A_RELEASE_KEYALIAS \
   --env P4A_RELEASE_KEYSTORE_PASSWD \


### PR DESCRIPTION
Rethinking how we cache things.

Have run into a few issues with cache being too aggressive, where dependency changes and pyeverywhere/python-for-android changes wouldn't propagate during build time in the pipeline.

Reworking the order of that. Changes for our vendored versions of those are now checked fore before installation so that cache invalidates on update.

android distro caches now happen inside of volumes and are mounted between builds, so those aren't invalidated unless we need different SDK/NDKs. Easy to delete, too: `docker volume rm <name of volume>`

And I de-prioritized source code reuse, as the source is actually really small. Meaning we can now deploy this image and have it run cache-less if we want, just as docker intended.