### PR TITLE
Set KOLIBRI_RUN_MODE based on signing key for APK (dev, testing, prod)

### DIFF
--- a/src/initialization.py
+++ b/src/initialization.py
@@ -1,5 +1,6 @@
 import os
 import pew.ui
+import re
 import sys
 
 
@@ -10,12 +11,22 @@ sys.path.append(os.path.join(script_dir, "extra-packages"))
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri_app_settings"
 
-# TODO: before shipping the app, make this contingent on debug vs production mode
-os.environ["KOLIBRI_RUN_MODE"] = "pew-dev"
-
 
 if pew.ui.platform == "android":
     # initialize some system environment variables needed to run smoothly on Android
-    from android_utils import get_timezone_name
+
+    from android_utils import get_timezone_name, get_signature_key_issuing_organization
+
+    signing_org = get_signature_key_issuing_organization()
+    if signing_org == "Learning Equality":
+        runmode = "android-testing"
+    elif signing_org == "Android":
+        runmode = "android-debug"
+    elif signing_org == "Google Inc.":
+        runmode = ""  # Play Store!
+    else:
+        runmode = "android-" + re.sub(r"[^a-z ]", "", signing_org.lower()).replace(" ", "-")
+    os.environ["KOLIBRI_RUN_MODE"] = runmode
+
     os.environ["TZ"] = get_timezone_name()
     os.environ["LC_ALL"] = "en_US.UTF-8"


### PR DESCRIPTION
As discussed on Slack -- it checks the org that signed the installed APK, and sets the run mode based on that. It distinguishes between dev/debug APKs (signed locally), regular production builds (signed by LE) and released builds (signed by Google via the Play Store).