### PR TITLE
Revert "Make it possible to make non-dev builds via Buildkite"

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,10 +7,10 @@ steps:
   - label: "Build Dev Android APK (32bit) :tada:"
     command: ".buildkite/build.sh"
     env:
-      KOLIBRI_ANDROID_BUILD_MODE: build.env("LE_KOLIBRI_RELEASE", "dev")
+      KOLIBRI_ANDROID_BUILD_MODE: "dev"
 
   - label: "Build Dev Android APK (64bit) :tada:"
     command: ".buildkite/build.sh"
     env:
-      KOLIBRI_ANDROID_BUILD_MODE: build.env("LE_KOLIBRI_RELEASE", "dev")
+      KOLIBRI_ANDROID_BUILD_MODE: "dev"
       ARCH: "64bit"


### PR DESCRIPTION
Reverting commit - Conditionals do not apply within envar specs in Buildkite commands steps.

This reverts commit 90c48f0578f1142b5331909b613928160f7b3c55.