### PR TITLE
Update to target API level 30, and prepare for Kolibri 0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,14 @@ ENV P4A_BRANCH=pew_webview
 
 # Allows us to invalidate cache if those repos update.
 # Intentionally not pinning for dev velocity.
-ADD https://github.com/kollivier/pyeverywhere/archive/$PEW_BRANCH.zip pew.zip
-ADD https://github.com/kollivier/python-for-android/archive/$P4A_BRANCH.zip p4a.zip
+ADD https://github.com/learningequality/pyeverywhere/archive/$PEW_BRANCH.zip pew.zip
+ADD https://github.com/learningequality/python-for-android/archive/$P4A_BRANCH.zip p4a.zip
 
 # install python dependencies
 RUN pip install cython virtualenv pbxproj && \
   # get kevin's custom packages
-  pip install -e git+https://github.com/kollivier/pyeverywhere@$PEW_BRANCH#egg=pyeverywhere && \
-  pip install -e git+https://github.com/kollivier/python-for-android@$P4A_BRANCH#egg=python-for-android && \
+  pip install -e git+https://github.com/learningequality/pyeverywhere@$PEW_BRANCH#egg=pyeverywhere && \
+  pip install -e git+https://github.com/learningequality/python-for-android@$P4A_BRANCH#egg=python-for-android && \
   useradd -lm kivy
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ preseeded_kolibri_home:
 	pip uninstall kolibri 2> /dev/null || true
 	pip install --target tmpenv whl/*.whl
 	tmpenv/bin/kolibri plugin enable kolibri.plugins.app
-	tmpenv/bin/kolibri start --port=16294
+	tmpenv/bin/kolibri start --port=0
 	sleep 1
 	tmpenv/bin/kolibri stop
 	sleep 1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project was primarily developed on Docker, so this method is more rigorousl
 
 ## Build on Host
 
-1. Install [PyEverywhere](https://github.com/kollivier/pyeverywhere) and its build dependencies (for building Python). For Ubuntu, you can find the list of dependencies in the [Dockerfile](./Dockerfile).
+1. Install [PyEverywhere](https://github.com/learningequality/pyeverywhere) and its build dependencies (for building Python). For Ubuntu, you can find the list of dependencies in the [Dockerfile](./Dockerfile).
 
 2. Build or download a Kolibri WHL file, and place it in the `whl/` directory.
 

--- a/project_info.template
+++ b/project_info.template
@@ -12,7 +12,7 @@
     "android": {
       "services": ["kolibri:android_service.py"],
       "extra_permissions": ["FOREGROUND_SERVICE"],
-      "sdk": 29,
+      "sdk": 30,
       "minsdk": 21,
       "fileprovider_paths_filename": "fileprovider_paths.xml"
     }


### PR DESCRIPTION
Port was updated to prevent zombies from blocking the build, and SDK level was bumped to enable uploads to Play Store with the new rules.

Relies on https://github.com/learningequality/pyeverywhere/pull/1 being merged first.