### PR TITLE
Allow a temporary SSH password to be set over ADB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN dpkg --add-architecture i386 && \
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && python3 get-pip.py
 
 # Ensure that python is using python3
 # copying approach from official python images

--- a/scripts/create_project_info.py
+++ b/scripts/create_project_info.py
@@ -81,7 +81,7 @@ def build_number():
         return str(build_number)
 
     print('Buildkite build # not found, using dev alternative')
-    alt_build_number = datetime.now().strftime('%y%m%d%H%M')
+    alt_build_number = (int(datetime.now().strftime('%y%m%d%H%M')) - build_base_number) * 2 + increment_for_64bit
     print(alt_build_number)
     return alt_build_number
 


### PR DESCRIPTION
Once a device has been set up as a single-user device, there's no way to run provisioning scripts against it anymore, as there are no admin credentials to use for connecting in by SSH to run management commands. This PR allows for a tempoary SSH password to be set over ADB (putting a file in KOLIBRI_HOME) to allow provisioning scripts to regain the necessary access as needed. The provisioning scripts (PR to be opened soon for them) remove this password file again immediately after connecting.

I tried using PubKey based authentication instead (based on an authorized_keys file), and I believe the code would all work except I couldn't (easily) get P4A to build the _crypt module, as no recipe was already in place, so this ended up being easier -- and since the password is temporary, and can only be set via an ADB connection that has full DB access anyway, it doesn't seem to introduce new risks.