### PR TITLE
Upgrade to Python 3.9

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -5,7 +5,7 @@
 --dist_name "kolibri"
 --private "src"
 --orientation sensor
---requirements python3,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six
+--requirements python3==3.9.12,hostpython3==3.9.12,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six
 --android-api 30
 --minsdk 21
 --permission WRITE_EXTERNAL_STORAGE


### PR DESCRIPTION
Change the p4a requirements to use Python version 3.9.12.

https://github.com/learningequality/kolibri-installer-android/issues/111