### PR TITLE
Proper cmdline-tools installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,20 +137,25 @@ logcat:
 	$(ADB) logcat | grep -i -E "python|kolibr| `$(ADB) shell ps | grep ' org.learningequality.Kolibri$$' | tr -s [:space:] ' ' | cut -d' ' -f2` " | grep -E -v "WifiTrafficPoller|localhost:5000|NetworkManagementSocketTagger|No jobs to start"
 
 $(SDK)/cmdline-tools:
-	@echo "Downloading Android SDK build tools"
+	@echo "Downloading Android SDK command line tools"
 	wget https://dl.google.com/android/repository/commandlinetools-$(PLATFORM)-7583922_latest.zip
-	unzip commandlinetools-$(PLATFORM)-7583922_latest.zip -d $(SDK)
+	rm -rf cmdline-tools
+	unzip commandlinetools-$(PLATFORM)-7583922_latest.zip
+# This is unfortunate since it will download the command line tools
+# again, but after this it will be properly installed and updatable.
+	yes y | ./cmdline-tools/bin/sdkmanager "cmdline-tools;latest" --sdk_root=$(SDK)
+	rm -rf cmdline-tools
 	rm commandlinetools-$(PLATFORM)-7583922_latest.zip
 
 sdk:
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "platform-tools" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "platforms;android-$(ANDROID_API)" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "build-tools;30.0.3" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "ndk;$(ANDROIDNDKVER)" --sdk_root=$(SDK)
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platform-tools"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platforms;android-$(ANDROID_API)"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "ndk;$(ANDROIDNDKVER)"
 	ln -sfT ndk/$(ANDROIDNDKVER) $(SDK)/ndk-bundle
 	@echo "Accepting all licenses"
-	yes | $(SDK)/cmdline-tools/bin/sdkmanager --licenses --sdk_root=$(SDK)
+	yes | $(SDK)/cmdline-tools/latest/bin/sdkmanager --licenses
 
 # All of these commands are non-destructive, so if the cmdline-tools are already installed, make will skip
 # based on the directory existing.

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ install:
 logcat:
 	$(ADB) logcat | grep -i -E "python|kolibr| `$(ADB) shell ps | grep ' org.learningequality.Kolibri$$' | tr -s [:space:] ' ' | cut -d' ' -f2` " | grep -E -v "WifiTrafficPoller|localhost:5000|NetworkManagementSocketTagger|No jobs to start"
 
-$(SDK)/cmdline-tools:
+$(SDK)/cmdline-tools/latest/bin/sdkmanager:
 	@echo "Downloading Android SDK command line tools"
 	wget https://dl.google.com/android/repository/commandlinetools-$(PLATFORM)-7583922_latest.zip
 	rm -rf cmdline-tools
@@ -147,7 +147,7 @@ $(SDK)/cmdline-tools:
 	rm -rf cmdline-tools
 	rm commandlinetools-$(PLATFORM)-7583922_latest.zip
 
-sdk:
+sdk: $(SDK)/cmdline-tools/latest/bin/sdkmanager
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platform-tools"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platforms;android-$(ANDROID_API)"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64"
@@ -162,8 +162,6 @@ sdk:
 # The SDK installations will take a little time, but will not attempt to redownload if already installed.
 setup:
 	$(MAKE) guard-ANDROID_HOME
-	mkdir -p $(SDK)
-	$(MAKE) $(SDK)/cmdline-tools
 	$(MAKE) sdk
 	@echo "Make sure to set the necessary environment variables"
 	@echo "export ANDROIDSDK=$(SDK)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cython
 virtualenv
-git+https://github.com/learningequality/python-for-android@e8a2ddff8a9b6a53c072ecd36dc5b5045fed290a#egg=python-for-android
+git+https://github.com/learningequality/python-for-android@f94ca9392c27eb30f46dab8a9583fb93d3ccafed#egg=python-for-android


### PR DESCRIPTION
This installs cmdline-tools in the "proper" way using sdkmanager itself. Mostly this is just moving the deck chairs around, but it also enables building using Java 11 on the host after learningequality/python-for-android#3.