### PR TITLE
Upgrade Python for Android to branch based off latest 2022.09.04

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -72,7 +72,7 @@ jobs:
         # have these SDKs and NDKs already installed.
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-3
         export ANDROIDSDK="$ANDROID_SDK_ROOT"
-        export ANDROIDNDK="$ANDROID_NDK_ROOT"
+        export ANDROIDNDK=/usr/local/lib/android/sdk/ndk/23.2.8568313
         make kolibri.apk.unsigned
     - name: Get APK filename
       id: get-apk-filename

--- a/.p4a
+++ b/.p4a
@@ -5,9 +5,10 @@
 --dist_name "kolibri"
 --private "src"
 --orientation sensor
---requirements python3==3.9.12,hostpython3==3.9.12,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six
---android-api 30
---minsdk 21
+--requirements python3==3.9.13,hostpython3==3.9.13,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six
+--android-api 31
+--minsdk 23
+--ndk-api 23
 --permission WRITE_EXTERNAL_STORAGE
 --permission ACCESS_NETWORK_STATE
 --permission FOREGROUND_SERVICE

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN dpkg --add-architecture i386 && \
     libtool \
     locales \
     lsb-release \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     python-dev \
     unzip \
     vim \

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ else
 	PLATFORM := linux
 endif
 
-ANDROID_API := 30
-ANDROIDNDKVER := 21.4.7075529
+ANDROID_API := 31
+ANDROIDNDKVER := 23.2.8568313
 
 SDK := ${ANDROID_HOME}/android-sdk-$(PLATFORM)
 
@@ -92,7 +92,7 @@ kolibri.apk: p4a_android_distro src/kolibri needs-version
 	@echo "--- :android: Build APK"
 	$(P4A) apk --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
 	mkdir -p dist
-	mv kolibri-release-$(APK_VERSION)-.apk dist/kolibri-release-$(APK_VERSION).apk
+	mv kolibri-release-$(APK_VERSION).apk dist/kolibri-release-$(APK_VERSION).apk
 
 .PHONY: kolibri.apk.unsigned
 # Build the unsigned debug version of the apk
@@ -101,7 +101,7 @@ kolibri.apk.unsigned: p4a_android_distro src/kolibri needs-version
 	@echo "--- :android: Build APK (unsigned)"
 	$(P4A) apk $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
 	mkdir -p dist
-	mv kolibri-debug-$(APK_VERSION)-.apk dist/kolibri-debug-$(APK_VERSION).apk
+	mv kolibri-debug-$(APK_VERSION).apk dist/kolibri-debug-$(APK_VERSION).apk
 
 .PHONY: kolibri.aab
 # Build the signed version of the aab
@@ -114,7 +114,7 @@ kolibri.aab: p4a_android_distro src/kolibri needs-version
 	@echo "--- :android: Build AAB"
 	$(P4A) aab --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
 	mkdir -p dist
-	mv kolibri-release-$(APK_VERSION)-.aab dist/kolibri-release-$(APK_VERSION).aab
+	mv kolibri-release-$(APK_VERSION).aab dist/kolibri-release-$(APK_VERSION).aab
 
 # DOCKER BUILD
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
 cython
 virtualenv
-git+https://github.com/learningequality/python-for-android@f94ca9392c27eb30f46dab8a9583fb93d3ccafed#egg=python-for-android
-# Pin sh to this version as p4a relies on a bug whereby sh.which returns None
-# instead of raising exit code 1 when no executable can be found.
-# Newer versions of Python for Android do not rely on this behaviour
-# so this constraint can be removed when we upgrade.
-sh==1.14.2
+git+https://github.com/learningequality/python-for-android@f100ec6d9ba8a2c73119932e0eaaad1dd6b42913#egg=python-for-android


### PR DESCRIPTION
Updates Python for Android to be based off the latest release.

Upgrades NDK to 23.

Upgrades Android API to 31.

Upgrades Java to 11.

Removes no longer necessary workaround for sh bug.

Fixes #124