### PR TITLE
Android Util - Get metered connection status from ConnectivityManager

### DIFF
--- a/src/android_utils.py
+++ b/src/android_utils.py
@@ -222,3 +222,12 @@ def get_signature_key_issuing_organization():
     else:
         print("Using cached value for issuing org")
     return value
+
+
+def is_active_network_metered():
+    ConnectivityManager = autoclass("android.net.ConnectivityManager")
+
+    return cast(
+        ConnectivityManager,
+        get_context().getSystemService(get_context().CONNECTIVITY_SERVICE),
+    ).isActiveNetworkMetered()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
+from android_utils import is_active_network_metered
 from android_utils import share_by_intent
 from jnius import autoclass
 from kolibri.main import enable_plugin
@@ -48,6 +49,7 @@ initialize()
 start_default_tasks()
 
 interface.register(share_file=share_by_intent)
+interface.register(check_is_metered=is_active_network_metered)
 
 kolibri_bus = BaseKolibriProcessBus()
 # Setup zeroconf plugin


### PR DESCRIPTION
I did a deep dive into the Java docs for ConnectivityManager and worked out how to do it in Java. Then, as I was working out how to connect the Java I wrote into the Python, I realized I could just do it without writing any Java at all thanks to `jnius` (unless I've missed something :sweat_smile: )

I've tested this both by building an APK with a Kolibri WHL that persistently showed the status of the metered connection on the device. Then, as I toggle the manual override in Android to treat a connection as metered, I toggle the output of the status in Kolibri.

Also it works when I SSH via `remoteshell` (which is amazing to have).

---

One thing I'd gotten stuck on early for a bit was that I was thinking we'd need to hook into the `ConnectivityManager.NetworkCallback` business so that we could react to a change.  After some though I figured that we can just call the function whenever we need to know the status -- rather than trying to register some Python code to run as a Java callback. 

I just wanted to share in case I've missed something there or if for some reason working that out would be better for some reason.