### PR TITLE
Intent for remote shell

### DIFF
--- a/python-for-android/dists/kolibri/src/main/AndroidManifest.xml
+++ b/python-for-android/dists/kolibri/src/main/AndroidManifest.xml
@@ -52,7 +52,14 @@
 
 
         <service android:name="org.learningequality.Kolibri.ServiceRemoteshell"
-                 android:process=":service_remoteshell" />
+                 android:permission=""
+                 android:exported="true"
+                 android:process=":service_remoteshell" >
+        <intent-filter>
+            <action android:name="org.learningequality.Kolibri.START_REMOTESHELL" />
+
+        </intent-filter>
+        </service>
 
 
         <service android:name="org.learningequality.Kolibri.TaskworkerWorkerService"

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/ServiceRemoteshell.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/ServiceRemoteshell.java
@@ -3,7 +3,7 @@ package org.learningequality.Kolibri;
 import android.content.Intent;
 import android.content.Context;
 import org.kivy.android.PythonService;
-
+import android.util.Log;
 
 public class ServiceRemoteshell extends PythonService {
 
@@ -35,8 +35,15 @@ public class ServiceRemoteshell extends PythonService {
                                           String contentTitle, String contentText,
                                           String pythonServiceArgument) {
         Intent intent = new Intent(ctx, ServiceRemoteshell.class);
-        String argument = ctx.getFilesDir().getAbsolutePath() + "/app";
-        intent.putExtra("androidPrivate", ctx.getFilesDir().getAbsolutePath());
+
+        return putExtraRemoteShell(intent, ctx, smallIconName, contentTitle, contentText, pythonServiceArgument);
+
+    }
+
+    static public Intent putExtraRemoteShell(Intent intent, Context context, String smallIconName, String contentTitle, String contentText,
+                                      String pythonServiceArgument) {
+        String argument = context.getFilesDir().getAbsolutePath() + "/app";
+        intent.putExtra("androidPrivate", context.getFilesDir().getAbsolutePath());
         intent.putExtra("androidArgument", argument);
         intent.putExtra("serviceTitle", "Kolibri");
         intent.putExtra("serviceEntrypoint", "remoteshell.py");
@@ -49,6 +56,20 @@ public class ServiceRemoteshell extends PythonService {
         intent.putExtra("contentTitle", contentTitle);
         intent.putExtra("contentText", contentText);
         return intent;
+
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Context context = getApplicationContext();
+        if (intent == null) {
+            intent = getThisDefaultIntent(context, "");
+        }
+        else {
+            intent = putExtraRemoteShell(intent, context, "", "kolibri", "ssh service", "");
+        }
+        Log.d("python AndroidRuntime Remoteshell", "Service starting");
+        return super.onStartCommand(intent, flags, startId);
     }
 
     @Override
@@ -60,5 +81,6 @@ public class ServiceRemoteshell extends PythonService {
     static public void stop(Context ctx) {
         Intent intent = new Intent(ctx, ServiceRemoteshell.class);
         ctx.stopService(intent);
+        Log.d("python AndroidRuntime Remoteshell", "Service stopped");
     }
 }


### PR DESCRIPTION
With the latest changes in the android build, remoteshell does not start by default when the app is started.
This PR creates the needed intent to start remoteshell using an adb command.

When using an intent, the start method of the service is not called, the `onStartCommand` is called directly in the [service lifecycle](https://developer.android.com/reference/android/app/Service#ServiceLifecycle). For this reason this method has been overriden in the `ServiceRemoteShell.java` file. If we don't call the service anymore from the android app using startservice we could remove most of the code that handles the `start`, only the `onStartCommand` method would be needed.

In order to start the shell:
`adb shell am startservice -n org.learningequality.Kolibri/org.learningequality.Kolibri.ServiceRemoteshell -a org.learningequality.Kolibri.START_REMOTESHELL`

to stop it:
`adb shell am stopservice -n org.learningequality.Kolibri/org.learningequality.Kolibri.ServiceRemoteshell -a org.learningequality.Kolibri.START_REMOTESHELL`

Closes: #150 



NOTE: If this is approved, https://github.com/learningequality/kolibri-provisioning-tools/blob/master/kolibri_provisioning_tools/clients.py must be modified to use this mechanism. Then #143 can be solved.