### PR TITLE
Handle tracks with no releases key.

### DIFF
--- a/scripts/play_store_api.py
+++ b/scripts/play_store_api.py
@@ -61,7 +61,7 @@ def get_latest_version_code():
     )
     versionCode = 0
     for track in tracks:
-        for release in track["releases"]:
+        for release in track.get("releases", []):
             for vc in release.get("versionCodes", []):
                 versionCode = max(versionCode, int(vc))
     # Clean up after ourselves!


### PR DESCRIPTION
Apparently, it is possible for the `track` object returned by the Play Store API to be missing a releases key.

See below:
```
[{'track': 'production',
  'releases': [{'name': '0.13.3a0.dev0+git.18.g5c58205f-87562b7-official',
    'versionCodes': ['2004262131', '2004262134'],
    'releaseNotes': [{'language': 'en-US',
      'text': 'Initial pre-release version'}],
    'status': 'draft'}]},
 {'track': 'beta'},
 {'track': 'alpha',
  'releases': [{'name': '0.15.9',
    'releaseNotes': [{'language': 'en-US',
      'text': 'UI enhancements, and a series of fixes around learner progress tracking for resources, metadata display, and search.'}],
    'status': 'draft'},
   {'name': '0.15.6',
    'versionCodes': ['2009007882', '2009007883'],
    'status': 'completed'}]},
 {'track': 'internal',
  'releases': [{'name': '0.16.0b4-0.1.0-official',
    'versionCodes': ['2009007886'],
    'status': 'completed'}]},
 {'track': 'Pre-release testing',
  'releases': [{'name': '0.13.3a0.dev0+git.18.g5c58205f-87562b7-official',
    'versionCodes': ['2004262131', '2004262134'],
    'releaseNotes': [{'language': 'en-US',
      'text': 'Initial pre-release version'}],
    'status': 'completed'}]}]
```

This adds defensive handling for that scenario.

Fixes [#157](https://github.com/learningequality/kolibri-installer-android/issues/157)