### PR TITLE
Tweak logging to avoid repeated logging calls.

### DIFF
--- a/src/taskworker.py
+++ b/src/taskworker.py
@@ -5,15 +5,18 @@ from kolibri.main import initialize
 
 import __main__
 
+
 job_id = __main__.PYTHON_WORKER_ARGUMENT
 
-logging.info("Starting Kolibri task worker, for job {}".format(job_id))
-
 initialize(skip_update=True)
+
+logger = logging.getLogger(__name__)
+logger.info("Starting Kolibri task worker, for job {}".format(job_id))
+
 
 # Import this after we have initialized Kolibri
 from kolibri.core.tasks.worker import execute_job  # noqa: E402
 
 execute_job(job_id)
 
-logging.info("Ending Kolibri task worker, for job {}".format(job_id))
+logger.info("Ending Kolibri task worker, for job {}".format(job_id))


### PR DESCRIPTION
Fixes [#156](https://github.com/learningequality/kolibri-installer-android/issues/156)

Which appears after closer examination of the logs to just be an issue with the root logger having an additional handler added to it after Kolibri has been initialized.

Solves this by using a named logger, and holding off on logging until after Kolibri has been initialized.