### PR TITLE
Update target sdk version to 33.

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -5,7 +5,7 @@
 --dist_name "kolibri"
 --private "src"
 --requirements python3==3.9.13,hostpython3==3.9.13,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six,kolibri,ifaddr
---android-api 31
+--android-api 33
 --minsdk 23
 --ndk-api 23
 --permission ACCESS_NETWORK_STATE

--- a/python-for-android/dists/kolibri/build.gradle
+++ b/python-for-android/dists/kolibri/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode code
         versionName name
         manifestPlaceholders = [:]


### PR DESCRIPTION
I rebuilt this locally with the new API version and Kolibri loaded successfully, so I think this is good to go.

Noting that this is required in order to be able to publish to the Play Store any more.