### PR TITLE
Filter Network Interfaces to only those that we should listen on

### DIFF
--- a/python-for-android/dists/kolibri/build.gradle
+++ b/python-for-android/dists/kolibri/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
     buildToolsVersion '34.0.0'
     def versionPropsFile = file('version.properties')
     Properties versionProps = new Properties()

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/FullScreen.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/FullScreen.java
@@ -35,7 +35,7 @@ public class FullScreen {
         WebSettings webSettings = mWebView.getSettings();
         webSettings.setJavaScriptEnabled(true);
         webSettings.setAllowFileAccess(true);
-        webSettings.setAppCacheEnabled(true);
+        webSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
     }
 
     private class MyChrome extends WebChromeClient {

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/NetworkUtils.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/NetworkUtils.java
@@ -1,0 +1,54 @@
+package org.learningequality;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+public class NetworkUtils {
+
+    public static List<String> getActiveIPv4Addresses() {
+        List<String> ipAddresses = new ArrayList<>();
+
+        List<NetworkInterface> networkInterfaces;
+        try {
+            networkInterfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+        } catch (SocketException e) {
+            e.printStackTrace();
+            return ipAddresses; // Return empty list if there's a problem fetching network interfaces
+        }
+
+        for (NetworkInterface networkInterface : networkInterfaces) {
+            try {
+                // Check if the network interface is up (active)
+                if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+                    continue;  // Skip inactive interfaces, and loopback ones
+                }
+
+                // Check if the network interface supports multicast
+                if (!networkInterface.supportsMulticast()) {
+                    continue;  // Skip interfaces that don't support multicast
+                }
+
+                // Get all IP addresses associated with the interface
+                List<InetAddress> inetAddresses = Collections.list(networkInterface.getInetAddresses());
+
+                for (InetAddress inetAddress : inetAddresses) {
+                    // Ensure this is an IPv4 address
+                    if (inetAddress instanceof Inet4Address) {
+                        ipAddresses.add(inetAddress.getHostAddress());
+                    }
+                }
+            } catch (SocketException e) {
+                e.printStackTrace();  // Handle or log the error for this particular network interface
+                // Continue with the next interface
+            }
+        }
+
+        return ipAddresses;
+    }
+}

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/NetworkUtils.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/NetworkUtils.java
@@ -25,13 +25,8 @@ public class NetworkUtils {
         for (NetworkInterface networkInterface : networkInterfaces) {
             try {
                 // Check if the network interface is up (active)
-                if (!networkInterface.isUp() || networkInterface.isLoopback()) {
-                    continue;  // Skip inactive interfaces, and loopback ones
-                }
-
-                // Check if the network interface supports multicast
-                if (!networkInterface.supportsMulticast()) {
-                    continue;  // Skip interfaces that don't support multicast
+                if (!networkInterface.isUp() || !networkInterface.supportsMulticast()) {
+                    continue;  // Skip inactive interfaces, and interfaces that don't support multicast
                 }
 
                 // Get all IP addresses associated with the interface

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 import kolibri  # noqa: F401  Import Kolibri here so we can import modules from dist folder
+import monkey_patch_zeroconf  # noqa: F401 Import this to patch zeroconf
 from android_utils import get_context
 from android_utils import get_home_folder
 from android_utils import get_signature_key_issuing_organization

--- a/src/monkey_patch_zeroconf.py
+++ b/src/monkey_patch_zeroconf.py
@@ -1,0 +1,11 @@
+import zeroconf
+from jnius import autoclass
+
+NetworkUtils = autoclass("org.learningequality.NetworkUtils")
+
+
+def get_all_addresses():
+    return list(NetworkUtils.getActiveIPv4Addresses())
+
+
+zeroconf.get_all_addresses = get_all_addresses


### PR DESCRIPTION
Fixes #164

Updates the compileSdk in build.gradle
Updates deprecated method for setting the webview cache