### PR TITLE
Fix task interference bugs and task repeating

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cython~=0.29
 ifaddr
 virtualenv
 setuptools
-git+https://github.com/learningequality/python-for-android@4a3c74caf67cad4495f2352ae56ba2b0f1b266c5#egg=python-for-android
+git+https://github.com/learningequality/python-for-android@5eff8c9f79c8f019073cc7e913219f5ac219ac32#egg=python-for-android
 google-api-python-client==2.96.0
 google-auth==2.22.0
 google-auth-httplib2==0.1.0

--- a/src/taskworker.py
+++ b/src/taskworker.py
@@ -3,20 +3,18 @@ import logging
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
 from kolibri.main import initialize
 
-import __main__
-
-
-job_id = __main__.PYTHON_WORKER_ARGUMENT
 
 initialize(skip_update=True)
 
 logger = logging.getLogger(__name__)
-logger.info("Starting Kolibri task worker, for job {}".format(job_id))
 
 
-# Import this after we have initialized Kolibri
-from kolibri.core.tasks.worker import execute_job  # noqa: E402
+def main(job_id):
+    logger.info("Starting Kolibri task worker, for job {}".format(job_id))
 
-execute_job(job_id)
+    # Import this after we have initialized Kolibri
+    from kolibri.core.tasks.worker import execute_job  # noqa: E402
 
-logger.info("Ending Kolibri task worker, for job {}".format(job_id))
+    execute_job(job_id)
+
+    logger.info("Ending Kolibri task worker, for job {}".format(job_id))


### PR DESCRIPTION
* Simplifies how we use task manager to only use single enqueuing of a task, and rely on Kolibri's task requeuing within the life cycle of a task to handle repeat behaviour
* Updates to always use `APPEND_OR_REPLACE` to ensure that tasks append while running or replace if not running.
* Updates Python for Android to a version on our fork that allow defining a `main` function in the specified module that will be executed if it exists - it is passed what would normally be passed as the environment variable argument as its sole argument
* This helps prevent the environment variable getting set to the incorrect value when multiple threads are operating (as they do in the work manager context) - this means that job execution will always be passed the proper job_id, and not accidentally read the incorrect job_id from either from an environment variable or a variable set on the `__main__` module that is shared across threads.

I tested this with a dummy task defined in the `android_app_plugin` that used the `retry_in` method of the job object to repeat itself every 5 seconds. It did this successfully, and also did not interfere or attempt to run other currently active tasks (such as the ping back task or the network connection checking task) which I had seen in previous testing.

Full diff for the change in our P4A fork here: https://github.com/learningequality/python-for-android/compare/4a3c74caf67cad4495f2352ae56ba2b0f1b266c5...5eff8c9f79c8f019073cc7e913219f5ac219ac32