### PR TITLE
Notification tweaks

### DIFF
--- a/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
@@ -35,8 +35,6 @@ public class PythonWorker extends RemoteListenableWorker {
 
     public static PythonWorker mWorker = null;
 
-    public int notificationId;
-
     public static ThreadLocal<Integer> threadNotificationId = new ThreadLocal<>();
 
     private String notificationTitle;
@@ -50,7 +48,7 @@ public class PythonWorker extends RemoteListenableWorker {
 
         notificationTitle = context.getString(R.string.app_name);
 
-        notificationId = ThreadLocalRandom.current().nextInt(1, 65537);
+        threadNotificationId.set(ThreadLocalRandom.current().nextInt(1, 65537));
 
         PythonWorker.mWorker = this;
 
@@ -85,6 +83,8 @@ public class PythonWorker extends RemoteListenableWorker {
             if (longRunning) {
                 runAsForeground();
             }
+
+            int notificationId = getNotificationId();
 
             // The python thread handling the work needs to be run in a
             // separate thread so that future can be returned. Without
@@ -138,7 +138,7 @@ public class PythonWorker extends RemoteListenableWorker {
     );
 
     public ForegroundInfo getForegroundInfo() {
-        return new ForegroundInfo(notificationId, Notifications.createNotification(notificationTitle, null, -1, -1));
+        return new ForegroundInfo(getNotificationId(), Notifications.createNotification(notificationTitle, null, -1, -1));
     }
 
     public void runAsForeground() {

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Notifications.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Notifications.java
@@ -2,6 +2,8 @@ package org.learningequality;
 
 import android.app.Notification;
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -34,8 +36,10 @@ public class Notifications {
     }
 
     public static void hideNotification(int notificationId) {
-        Context context = ContextUtil.getApplicationContext();
-        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-        notificationManager.cancel(notificationId);
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+            Context context = ContextUtil.getApplicationContext();
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            notificationManager.cancel(notificationId);
+        }, 5000); // Delay in milliseconds (5 seconds)
     }
 }


### PR DESCRIPTION
* Makes a small tweak to how the notificationId is accessed across threads, to ensure that we are always initializing and referencing a thread local variable for the notificationId - possible that this could have caused confusion across multiple synchronous worker threads as to which notificationId was meant to managed
* Adds 5 second delay to clearing of notifications when called. This should ensure that we don't rapidly display and hide ids in the case of slower devices, and in the case of faster devices, that the notification has had a chance to be created before we try to hide it!

Debug build of APK will be here: https://github.com/learningequality/kolibri-installer-android/actions/runs/6930362719

Note that this is built using the Kolibri beta 8 release, so this will exhibit previously logged syncing issues and is not a cause for new concern - this only fixes issues with notifications!

Fixes #174