### PR TITLE
Revert "Merge pull request #175 from learningequality/notifications"

### DIFF
--- a/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
@@ -35,6 +35,8 @@ public class PythonWorker extends RemoteListenableWorker {
 
     public static PythonWorker mWorker = null;
 
+    public int notificationId;
+
     public static ThreadLocal<Integer> threadNotificationId = new ThreadLocal<>();
 
     private String notificationTitle;
@@ -48,7 +50,7 @@ public class PythonWorker extends RemoteListenableWorker {
 
         notificationTitle = context.getString(R.string.app_name);
 
-        threadNotificationId.set(ThreadLocalRandom.current().nextInt(1, 65537));
+        notificationId = ThreadLocalRandom.current().nextInt(1, 65537);
 
         PythonWorker.mWorker = this;
 
@@ -83,8 +85,6 @@ public class PythonWorker extends RemoteListenableWorker {
             if (longRunning) {
                 runAsForeground();
             }
-
-            int notificationId = getNotificationId();
 
             // The python thread handling the work needs to be run in a
             // separate thread so that future can be returned. Without
@@ -138,7 +138,7 @@ public class PythonWorker extends RemoteListenableWorker {
     );
 
     public ForegroundInfo getForegroundInfo() {
-        return new ForegroundInfo(getNotificationId(), Notifications.createNotification(notificationTitle, null, -1, -1));
+        return new ForegroundInfo(notificationId, Notifications.createNotification(notificationTitle, null, -1, -1));
     }
 
     public void runAsForeground() {

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Notifications.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Notifications.java
@@ -2,8 +2,6 @@ package org.learningequality;
 
 import android.app.Notification;
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -36,10 +34,8 @@ public class Notifications {
     }
 
     public static void hideNotification(int notificationId) {
-        new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            Context context = ContextUtil.getApplicationContext();
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-            notificationManager.cancel(notificationId);
-        }, 5000); // Delay in milliseconds (5 seconds)
+        Context context = ContextUtil.getApplicationContext();
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        notificationManager.cancel(notificationId);
     }
 }


### PR DESCRIPTION
Reverts the PR https://github.com/learningequality/kolibri-installer-android/pull/175

The following errors were observed:
```
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: 	at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: 	at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: 	at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
11-23 19:59:59.520 13177 13203 E WM-WorkerWrapper: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
```
And
```
11-24 16:07:51.269  1435  5625 W ActivityManager: Scheduling restart of crashed service org.learningequality.Kolibri/.TaskworkerWorkerService in 1000ms for connection
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper: Work [ id=1032c3f4-c0d3-47ac-8e12-7243112e77eb, tags={ kolibri_job_type:kolibri.core.auth.tasks.soud_sync_processing, kolibri_task_id:50, org.learningequality.Kolibri.TaskworkerWorker } ] failed because it threw an exception/error
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Binder died
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper:      at androidx.work.impl.utils.futures.AbstractFuture.getDoneValue(AbstractFuture.java:516)
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper:      at androidx.work.impl.utils.futures.AbstractFuture.get(AbstractFuture.java:475)
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper:      at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper:      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
11-24 16:07:51.271 19976 20022 E WM-WorkerWrapper:      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
11-24 16:07:51.273 19976 20022 I WM-WorkerWrapper: Worker result FAILURE for Work [ id=1032c3f4-c0d3-47ac-8e12-7243112e77eb, tags={ kolibri_job_type:kolibri.core.auth.tasks.soud_sync_processing, kolibri_task_id:50, org.learningequality.Kolibri.TaskworkerWorker } ]
```