### PR TITLE
Update to P4A version that fixes site-packages sys.path issue.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cython~=0.29
 ifaddr
 virtualenv
 setuptools
-git+https://github.com/learningequality/python-for-android@88ad22a420ed7aa90393a4eaed5762fd7de5e03b#egg=python-for-android
+git+https://github.com/learningequality/python-for-android@60f3bf7d653d3e4e97d8371feaef221ffcdeb421#egg=python-for-android
 google-api-python-client==2.96.0
 google-auth==2.22.0
 google-auth-httplib2==0.1.0


### PR DESCRIPTION
Diff: https://github.com/learningequality/python-for-android/compare/88ad22a420ed7aa90393a4eaed5762fd7de5e03b...learningequality:python-for-android:from_upstream_v2023.05.21