### PR TITLE
Small tweaks and cleanup

### DIFF
--- a/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonContext.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonContext.java
@@ -1,14 +1,64 @@
 package org.kivy.android;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.os.Build;
+import android.provider.Settings;
+
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PythonContext {
+    public static final String PACKAGE = "org.learningequality.Kolibri";
     public static PythonContext mInstance;
 
     private final Context context;
+    private final ConnectivityManager connectivityManager;
+    private final ConnectivityManager.NetworkCallback networkCallback;
+    private final AtomicBoolean isMetered = new AtomicBoolean(false);
+    private final String externalFilesDir;
+    private final String versionName;
+    private final String certificateInfo;
+    private final String nodeId;
 
     private PythonContext(Context context) {
         this.context = context;
+        this.connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        this.networkCallback = new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                super.onAvailable(network);
+                isMetered.set(connectivityManager.isActiveNetworkMetered());
+            }
+
+            @Override
+            public void onLost(Network network) {
+                super.onLost(network);
+                isMetered.set(false);
+            }
+        };
+
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build();
+
+        this.connectivityManager.registerNetworkCallback(networkRequest, this.networkCallback);
+
+        this.externalFilesDir = context.getExternalFilesDir(null).toString();
+
+        PackageInfo packageInfo = getPackageInfo();
+        this.versionName = packageInfo.versionName;
+
+        PackageInfo certificateInfo = getPackageInfo(PackageManager.GET_SIGNATURES);
+        this.certificateInfo = certificateInfo.signatures[0].toCharsString();
+
+        this.nodeId = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
     }
 
     public static PythonContext getInstance(Context context) {
@@ -24,10 +74,74 @@ public class PythonContext {
         return PythonContext.mInstance;
     }
 
+    // TODO: remove this, and don't store context on the class
     public static Context get() {
         if (PythonContext.mInstance == null) {
             return null;
         }
         return PythonContext.mInstance.context;
+    }
+
+    public static String getLocale() {
+        return Locale.getDefault().toLanguageTag();
+    }
+
+    public static Boolean isActiveNetworkMetered() {
+        if (PythonContext.mInstance == null) {
+            return null;
+        }
+        return PythonContext.mInstance.isMetered.get();
+    }
+
+    public static String getExternalFilesDir() {
+        if (PythonContext.mInstance == null) {
+            return null;
+        }
+        return PythonContext.mInstance.externalFilesDir;
+    }
+
+    public static String getVersionName() {
+        if (PythonContext.mInstance == null) {
+            return null;
+        }
+        return PythonContext.mInstance.versionName;
+    }
+
+    public static String getCertificateInfo() {
+        if (PythonContext.mInstance == null) {
+            return null;
+        }
+        return PythonContext.mInstance.certificateInfo;
+    }
+
+    public static String getNodeId() {
+        if (PythonContext.mInstance == null) {
+            return null;
+        }
+        return PythonContext.mInstance.nodeId;
+    }
+
+    public static void destroy() {
+        if (PythonContext.mInstance != null) {
+            PythonContext.mInstance.connectivityManager.unregisterNetworkCallback(PythonContext.mInstance.networkCallback);
+            PythonContext.mInstance = null;
+        }
+    }
+
+    protected PackageInfo getPackageInfo() {
+        return getPackageInfo(0);
+    }
+
+    protected PackageInfo getPackageInfo(int flags) {
+        PackageManager packageManager = context.getPackageManager();
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                return packageManager.getPackageInfo(PACKAGE, PackageManager.PackageInfoFlags.of(flags));
+            } else {
+                return packageManager.getPackageInfo(PACKAGE, flags);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new RuntimeException("Kolibri is not installed");
+        }
     }
 }

--- a/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/kivy/android/PythonWorker.java
@@ -9,11 +9,15 @@ import androidx.annotation.NonNull;
 import java.io.File;
 
 /**
- * Ideally this would be called `PythonWorkerImpl` but the name is used in the native code.
+ * Worker implementation that executes Python code.
+ *
+ * Ideally this would be called `PythonWorkerImpl` but the name is used in the native
+ * python-for-android code.
  */
 public class PythonWorker {
     private static final String TAG = "PythonWorkerImpl";
     // Python environment variables
+    private final Context context;
     private final String pythonName;
     private final String workerEntrypoint;
     private final String androidPrivate;
@@ -22,7 +26,7 @@ public class PythonWorker {
     private final String pythonPath;
 
     public PythonWorker(@NonNull Context context, String pythonName, String workerEntrypoint) {
-        PythonLoader.doLoad(context);
+        this.context = context;
         this.pythonName = pythonName;
         this.workerEntrypoint = workerEntrypoint;
 
@@ -31,6 +35,15 @@ public class PythonWorker {
         androidArgument = appRoot;
         pythonHome = appRoot;
         pythonPath = appRoot + ":" + appRoot + "/lib";
+    }
+
+    /**
+     * Prepare the Python environment.
+     *
+     * This should be called before any calls to `execute`.
+     */
+    public void prepare() {
+        PythonLoader.doLoad(context);
     }
 
     // Native part

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/ContextUtil.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/ContextUtil.java
@@ -1,6 +1,8 @@
 package org.learningequality;
 
+import android.app.ActivityManager;
 import android.content.Context;
+import android.os.Process;
 
 import org.kivy.android.PythonActivity;
 import org.learningequality.Kolibri.WorkerService;
@@ -22,5 +24,22 @@ public class ContextUtil {
 
     public static boolean isServiceContext() {
         return WorkerService.mService != null;
+    }
+
+    /**
+     * Get the name of the current process.
+     *
+     * @param context - the context to use
+     * @return the name of the current process as a string, or an empty string if not found
+     */
+    public static String getCurrentProcessName(Context context) {
+        int pid = Process.myPid();
+        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        for (ActivityManager.RunningAppProcessInfo processInfo : manager.getRunningAppProcesses()) {
+            if (processInfo.pid == pid) {
+                return processInfo.processName;
+            }
+        }
+        return "";
     }
 }

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/App.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/App.java
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.work.Configuration;
 
 import org.kivy.android.PythonContext;
+import org.learningequality.ContextUtil;
 import org.learningequality.notification.NotificationRef;
 
 import java.util.concurrent.Executors;
@@ -27,8 +28,12 @@ public class App extends Application implements Configuration.Provider {
         // Initialize Python context
         PythonContext.getInstance(this);
         createNotificationChannels();
-        // Register activity lifecycle callbacks
-        registerActivityLifecycleCallbacks(new KolibriActivityLifecycleCallbacks());
+
+        String currentProcessName = ContextUtil.getCurrentProcessName(this);
+        if (currentProcessName.endsWith(getString(R.string.task_worker_process))) {
+            // Register activity lifecycle callbacks
+            registerActivityLifecycleCallbacks(new KolibriActivityLifecycleCallbacks());
+        }
         WorkController.getInstance(this).wake();
     }
 

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/BackgroundWorker.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/BackgroundWorker.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.work.ListenableWorker;
 import androidx.work.WorkerParameters;
 
 import org.learningequality.task.Worker;
@@ -23,6 +24,10 @@ final public class BackgroundWorker extends androidx.work.Worker implements Work
     ) {
         super(context, workerParams);
         workerImpl = new PythonWorker(context, "TaskWorker", "taskworker.py");
+
+        // Ideally we wouldn't call this in the constructor, but we can't override `startWork` to
+        // call it just before `doWork` is called.
+        workerImpl.prepare();
     }
 
     /**

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/ForegroundWorker.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Kolibri/ForegroundWorker.java
@@ -41,6 +41,8 @@ final public class ForegroundWorker extends RemoteListenableWorker implements Wo
         final String id = getId().toString();
         final String arg = getArgument();
 
+        workerImpl.prepare();
+
         // See executor defined in configuration
         final ThreadPoolExecutor executor = (ThreadPoolExecutor) getBackgroundExecutor();
         // This is somewhat similar to what the plain `Worker` class does, except that we

--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Task.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Task.java
@@ -88,7 +88,14 @@ public class Task {
 
         final AtomicBoolean didReconcile = new AtomicBoolean(false);
         final JobStorage db = JobStorage.readwrite(context);
-        final Reconciler reconciler = Reconciler.from(context, db, executor);
+
+        final Reconciler reconciler;
+        try {
+            reconciler = Reconciler.from(context, db, executor);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to create reconciler", e);
+            return CompletableFuture.completedFuture(false);
+        }
 
         if (db == null) {
             Log.e(Sentinel.TAG, "Failed to open job storage database");

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -4,12 +4,11 @@ import sys
 
 import kolibri  # noqa: F401  Import Kolibri here so we can import modules from dist folder
 import monkey_patch_zeroconf  # noqa: F401 Import this to patch zeroconf
-from android_utils import get_context
 from android_utils import get_home_folder
+from android_utils import get_node_id
 from android_utils import get_signature_key_issuing_organization
 from android_utils import get_timezone_name
 from android_utils import get_version_name
-from jnius import autoclass
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(script_dir)
@@ -38,8 +37,7 @@ os.environ["KOLIBRI_CHERRYPY_THREAD_POOL"] = "2"
 
 
 def set_node_id():
-    Secure = autoclass("android.provider.Settings$Secure")
-    node_id = Secure.getString(get_context().getContentResolver(), Secure.ANDROID_ID)
+    node_id = get_node_id()
 
     # Don't set this if the retrieved id is falsy, too short, or a specific
     # id that is known to be hardcoded in many devices.


### PR DESCRIPTION
## Summary
- Removes file locking code, instead enforces reconciler only runs in the expected process, and uses thread locking
- Ensures we listen to activity lifecycle events in the main app process, to prevent duplication
- Separates step to load python libraries in worker implementation