### PR TITLE
Wrap notification updates in try catch to avoid errors

### DIFF
--- a/python-for-android/dists/kolibri/src/main/java/org/learningequality/Task.java
+++ b/python-for-android/dists/kolibri/src/main/java/org/learningequality/Task.java
@@ -188,7 +188,12 @@ public class Task {
             String id, String notificationTitle, String notificationText, int progress, int total
     ) {
         NotificationRef ref = Worker.buildNotificationRef(id);
-        Manager manager = new Manager(ContextUtil.getApplicationContext(), ref);
-        manager.send(notificationTitle, notificationText, progress, total);
+        try {
+            Context context = ContextUtil.getApplicationContext();
+            Manager manager = new Manager(context, ref);
+            manager.send(notificationTitle, notificationText, progress, total);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to update progress", e);
+        }
     }
 }


### PR DESCRIPTION
This seemed like the simplest way to handle these errors and stop them from breaking job execution, in local testing on a low powered Android 9 device, I confirmed that the errors were properly caught, and that tasks continued to run successfully. Also, notifications did not pile up and were properly cleared, in spite of errors.