### PR TITLE
Limit progress integers to less than or equal to 10000

### DIFF
--- a/src/android_app_plugin/kolibri_plugin.py
+++ b/src/android_app_plugin/kolibri_plugin.py
@@ -9,6 +9,7 @@ from kolibri.plugins.hooks import register_hook
 
 Locale = autoclass("java.util.Locale")
 Task = autoclass("org.learningequality.Task")
+PROGRESS_LIMIT = 10000
 
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,13 @@ class StorageHook(StorageHook):
             else:
                 progress = -1
                 total_progress = -1
+
+            # avoid passing integers that are too large
+            # PROGRESS_LIMIT gives sufficient precision for a % progress calculation
+            if total_progress > PROGRESS_LIMIT:
+                progress = progress // total_progress * PROGRESS_LIMIT
+                total_progress = PROGRESS_LIMIT
+
             Task.updateProgress(
                 orm_job.worker_extra,
                 status.title,


### PR DESCRIPTION
##  Summary
- Importing channel CK-12 onto a tablet, the task progress was updated with an integer that is too large, which it now reduces to <=10000 that gives sufficient precision for % progress tracking

## References
Fixes https://github.com/learningequality/kolibri-installer-android/issues/204