### PR TITLE
Update targetSdk to 34.

### DIFF
--- a/python-for-android/dists/kolibri/build.gradle
+++ b/python-for-android/dists/kolibri/build.gradle
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdk 34
         versionCode code
         versionName name
         manifestPlaceholders = [:]


### PR DESCRIPTION
This should allow the app to be installed on Android 14 devices.

I was not able to replicate #202 either on an emulator with Android 14 or my own physical Android 14 device, because it seems to be a Play Store based restriction. But I think updating the targetSDK should fix it.

Fixes #202 