### PR TITLE
Register `get_os_user` for the taskworker process

### DIFF
--- a/src/android_utils.py
+++ b/src/android_utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from functools import cache
+from uuid import uuid4
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -227,6 +228,21 @@ def get_dummy_user_name():
         value = get_string("Learner", currentLocale)
         value_cache.set(cache_key, value)
     return value
+
+
+def get_os_user_auth_token():
+    cache_key = "OS_USER_AUTH_TOKEN"
+    value = value_cache.get(cache_key)
+    if value is None:
+        value = uuid4().hex
+        value_cache.set(cache_key, value)
+    return value
+
+
+def os_user(auth_token):
+    if auth_token == get_os_user_auth_token():
+        return (get_dummy_user_name(), True)
+    return None, False
 
 
 def is_active_network_metered():

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 import logging
-from uuid import uuid4
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
-from android_utils import get_dummy_user_name
+from android_utils import get_os_user_auth_token
 from android_utils import is_active_network_metered
+from android_utils import os_user
 from android_utils import share_by_intent
 from jnius import autoclass
 from kolibri.main import enable_plugin
@@ -25,13 +25,7 @@ configureWebview(PythonActivity.mActivity)
 
 loadUrl = Runnable(PythonActivity.mWebView.loadUrl)
 
-auth_token_value = uuid4().hex
-
-
-def os_user(auth_token):
-    if auth_token == auth_token_value:
-        return (get_dummy_user_name(), True)
-    return None, False
+auth_token_value = get_os_user_auth_token()
 
 
 class AppPlugin(SimplePlugin):

--- a/src/taskworker.py
+++ b/src/taskworker.py
@@ -1,10 +1,12 @@
 import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
+from android_utils import os_user
 from kolibri.main import initialize
-
+from kolibri.plugins.app.utils import interface
 
 initialize(skip_update=True)
+interface.register(get_os_user=os_user)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

* Register `get_os_user` for the taskworker process.
* Store the os_user_authtoken in the cache.

## References

Will help to solve error where the taskworker process didnt had a get_os_user method registered in https://github.com/learningequality/kolibri/pull/13102.

## Reviewer guidance

Try running the android app using the build from https://github.com/learningequality/kolibri/pull/13102 and see if you can setup a full-facility device.
