### PR TITLE
Update dependabot to monthly schedule with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:
@@ -20,6 +21,7 @@ updates:
   - package-ecosystem: "gradle"
     directory: "python-for-android/dists/kolibri"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
- Change interval from weekly to monthly (triggers on 1st of month)
- Added cooldown of 7 days to avoid freshly released versions
- Applied to both github-actions and gradle ecosystems

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 