### PR TITLE
Migrate from kolibri.plugins.app to hook-based architecture

### DIFF
--- a/src/android_app_plugin/kolibri_plugin.py
+++ b/src/android_app_plugin/kolibri_plugin.py
@@ -1,7 +1,13 @@
 import logging
 
+from android_utils import is_active_network_metered
+from android_utils import os_user
+from android_utils import share_by_intent
 from django.utils import timezone
 from jnius import autoclass
+from kolibri.core.content.hooks import ShareFileHook
+from kolibri.core.device.hooks import CheckIsMeteredHook
+from kolibri.core.device.hooks import GetOSUserHook
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Priority
 from kolibri.plugins import KolibriPluginBase
@@ -18,6 +24,27 @@ logger = logging.getLogger(__name__)
 
 class AndroidApp(KolibriPluginBase):
     pass
+
+
+@register_hook
+class AndroidGetOSUserHook(GetOSUserHook):
+    def get_os_user(self, auth_token):
+        return os_user(auth_token)
+
+
+@register_hook
+class AndroidCheckIsMeteredHook(CheckIsMeteredHook):
+    def check_is_metered(self):
+        try:
+            return is_active_network_metered()
+        except Exception:
+            return False
+
+
+@register_hook
+class AndroidShareFileHook(ShareFileHook):
+    def share_file(self, filename, message):
+        share_by_intent(path=filename, message=message)
 
 
 @register_hook

--- a/src/main.py
+++ b/src/main.py
@@ -2,12 +2,9 @@ import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
 from android_utils import get_os_user_auth_token
-from android_utils import is_active_network_metered
-from android_utils import os_user
-from android_utils import share_by_intent
 from jnius import autoclass
+from kolibri.core.device.utils import app_initialize_url
 from kolibri.main import enable_plugin
-from kolibri.plugins.app.utils import interface
 from kolibri.utils.cli import initialize
 from kolibri.utils.server import BaseKolibriProcessBus
 from kolibri.utils.server import KolibriServerPlugin
@@ -36,22 +33,17 @@ class AppPlugin(SimplePlugin):
     def SERVING(self, port):
         start_url = "http://127.0.0.1:{port}".format(
             port=port
-        ) + interface.get_initialize_url(auth_token=auth_token_value)
+        ) + app_initialize_url(auth_token=auth_token_value)
         loadUrl(start_url)
 
 
 logging.info("Initializing Kolibri and running any upgrade routines")
 
 # activate app mode
-enable_plugin("kolibri.plugins.app")
 enable_plugin("android_app_plugin")
 
 # we need to initialize Kolibri to allow us to access the app key
 initialize()
-
-interface.register(share_file=share_by_intent)
-interface.register(check_is_metered=is_active_network_metered)
-interface.register(get_os_user=os_user)
 
 kolibri_bus = BaseKolibriProcessBus()
 # Setup zeroconf plugin
@@ -72,3 +64,4 @@ alt_port_server.subscribe()
 app_plugin = AppPlugin(kolibri_bus)
 app_plugin.subscribe()
 kolibri_bus.run()
+

--- a/src/taskworker.py
+++ b/src/taskworker.py
@@ -1,12 +1,9 @@
 import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
-from android_utils import os_user
 from kolibri.main import initialize
-from kolibri.plugins.app.utils import interface
 
 initialize(skip_update=True)
-interface.register(get_os_user=os_user)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Resolves #253

- Add GetOSUserHook, CheckIsMeteredHook, ShareFileHook to kolibri_plugin.py
- Replace interface.get_initialize_url() with app_initialize_url() in main.py
- Remove enable_plugin('kolibri.plugins.app') and all interface.register() calls
- Remove legacy kolibri.plugins.app imports from taskworker.py
