### PR TITLE
Migrate according to new hooks architecture in PR#12879

### DIFF
--- a/src/android_app_plugin/kolibri_plugin.py
+++ b/src/android_app_plugin/kolibri_plugin.py
@@ -2,10 +2,17 @@ import logging
 
 from django.utils import timezone
 from jnius import autoclass
+from kolibri.core.device.hooks import CheckIsMeteredHook
+from kolibri.core.device.hooks import GetOSUserHook
+from kolibri.core.device.hooks import ShareFileHook
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Priority
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+
+from android_utils import is_active_network_metered
+from android_utils import os_user
+from android_utils import share_by_intent
 
 Locale = autoclass("java.util.Locale")
 Task = autoclass("org.learningequality.Task")
@@ -18,6 +25,27 @@ logger = logging.getLogger(__name__)
 
 class AndroidApp(KolibriPluginBase):
     pass
+
+
+@register_hook
+class AndroidGetOSUserHook(GetOSUserHook):
+    def get_os_user(self, auth_token=None):
+        return os_user(auth_token)
+
+
+@register_hook
+class AndroidCheckIsMeteredHook(CheckIsMeteredHook):
+    def check_is_metered(self):
+        try:
+            return bool(is_active_network_metered())
+        except Exception:
+            return False
+
+
+@register_hook
+class AndroidShareFileHook(ShareFileHook):
+    def share_file(self, *args, **kwargs):
+        return share_by_intent(*args, **kwargs)
 
 
 @register_hook

--- a/src/android_app_plugin/kolibri_plugin.py
+++ b/src/android_app_plugin/kolibri_plugin.py
@@ -1,5 +1,8 @@
 import logging
 
+from android_utils import is_active_network_metered
+from android_utils import os_user
+from android_utils import share_by_intent
 from django.utils import timezone
 from jnius import autoclass
 from kolibri.core.device.hooks import CheckIsMeteredHook
@@ -9,10 +12,6 @@ from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Priority
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
-
-from android_utils import is_active_network_metered
-from android_utils import os_user
-from android_utils import share_by_intent
 
 Locale = autoclass("java.util.Locale")
 Task = autoclass("org.learningequality.Task")

--- a/src/main.py
+++ b/src/main.py
@@ -31,9 +31,9 @@ class AppPlugin(SimplePlugin):
         self.bus.subscribe("SERVING", self.SERVING)
 
     def SERVING(self, port):
-        start_url = "http://127.0.0.1:{port}".format(
-            port=port
-        ) + app_initialize_url(auth_token=auth_token_value)
+        start_url = "http://127.0.0.1:{port}".format(port=port) + app_initialize_url(
+            auth_token=auth_token_value
+        )
         loadUrl(start_url)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,12 +2,9 @@ import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
 from android_utils import get_os_user_auth_token
-from android_utils import is_active_network_metered
-from android_utils import os_user
-from android_utils import share_by_intent
 from jnius import autoclass
+from kolibri.core.device.utils import app_initialize_url
 from kolibri.main import enable_plugin
-from kolibri.plugins.app.utils import interface
 from kolibri.utils.cli import initialize
 from kolibri.utils.server import BaseKolibriProcessBus
 from kolibri.utils.server import KolibriServerPlugin
@@ -36,22 +33,17 @@ class AppPlugin(SimplePlugin):
     def SERVING(self, port):
         start_url = "http://127.0.0.1:{port}".format(
             port=port
-        ) + interface.get_initialize_url(auth_token=auth_token_value)
+        ) + app_initialize_url(auth_token=auth_token_value)
         loadUrl(start_url)
 
 
 logging.info("Initializing Kolibri and running any upgrade routines")
 
-# activate app mode
-enable_plugin("kolibri.plugins.app")
+
 enable_plugin("android_app_plugin")
 
 # we need to initialize Kolibri to allow us to access the app key
 initialize()
-
-interface.register(share_file=share_by_intent)
-interface.register(check_is_metered=is_active_network_metered)
-interface.register(get_os_user=os_user)
 
 kolibri_bus = BaseKolibriProcessBus()
 # Setup zeroconf plugin

--- a/src/taskworker.py
+++ b/src/taskworker.py
@@ -1,12 +1,11 @@
 import logging
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
-from android_utils import os_user
+from kolibri.main import enable_plugin
 from kolibri.main import initialize
-from kolibri.plugins.app.utils import interface
 
+enable_plugin("android_app_plugin")
 initialize(skip_update=True)
-interface.register(get_os_user=os_user)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Migrates Android wrapper to the new hook-based architecture, implementing:
	- GetOSUserHook 
	- CheckIsMeteredHook 
	- ShareFileHook
- Updates WebView initialization URL building to use `app_initialize_url` from `kolibri.core.device.utils`.

## References
closes #253

## Reviewer guidance
- Run the build and check if everything.