### PR TITLE
Fix hook imports to align with Kolibri PR #12879

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from play_store_api import get_latest_version_code
 
 
-android_installer_version = "0.1.8"
+android_installer_version = "0.1.9"
 
 
 BUILD_TYPE_DEBUG = "debug"

--- a/src/android_app_plugin/kolibri_plugin.py
+++ b/src/android_app_plugin/kolibri_plugin.py
@@ -5,10 +5,10 @@ from android_utils import os_user
 from android_utils import share_by_intent
 from django.utils import timezone
 from jnius import autoclass
+from kolibri.core.content.hooks import ShareFileHook
 from kolibri.core.device.hooks import CheckIsMeteredHook
 from kolibri.core.device.hooks import GetOSUserHook
-from kolibri.core.device.hooks import ShareFileHook
-from kolibri.core.tasks.hooks import StorageHook
+from kolibri.core.tasks.hooks import JobHook
 from kolibri.core.tasks.job import Priority
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
@@ -43,12 +43,12 @@ class AndroidCheckIsMeteredHook(CheckIsMeteredHook):
 
 @register_hook
 class AndroidShareFileHook(ShareFileHook):
-    def share_file(self, *args, **kwargs):
-        return share_by_intent(*args, **kwargs)
+    def share_file(self, filename, message):
+        return share_by_intent(filename, message)
 
 
 @register_hook
-class StorageHook(StorageHook):
+class AndroidJobHook(JobHook):
     def schedule(
         self,
         job,


### PR DESCRIPTION
## Summary

Fixes import paths in `kolibri_plugin.py` to match the hook locations in Kolibri PR learningequality/kolibri#12879:
- `ShareFileHook`: `kolibri.core.device.hooks` → `kolibri.core.content.hooks`
- `StorageHook` → `JobHook` in `kolibri.core.tasks.hooks`
- `share_file` signature updated to match new API (`filename`, `message`)

Also bumps `android_installer_version` to 0.1.9.

## References

- learningequality/kolibri#12879
- learningequality/kolibri-installer-android#263

## Reviewer guidance

Build an APK against the `hooked_on_plugins` branch of Kolibri and verify the app launches without `ImportError` crashes.

## AI usage

Used Claude Code to smoke test an APK on an emulator, diagnose the startup crash from logcat, cross-reference the hook import paths against learningequality/kolibri#12879, and make the fixes.